### PR TITLE
Retry fetching CLI installer script.

### DIFF
--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -15,9 +15,9 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.version }}" = "latest" ]; then
-          bash <(curl -fsSL https://metaplay.github.io/cli/install.sh)
+          bash <(curl -fsSL --retry 10 --retry-all-errors --retry-max-time 60 https://metaplay.github.io/cli/install.sh)
         else
-          bash <(curl -fsSL https://metaplay.github.io/cli/install.sh) --version ${{ inputs.version }}
+          bash <(curl -fsSL --retry 10 --retry-all-errors --retry-max-time 60 https://metaplay.github.io/cli/install.sh) --version ${{ inputs.version }}
         fi
 
     - name: Authenticate to Metaplay cloud


### PR DESCRIPTION
Add 60 seconds of retries to fetching `cli/install.sh`. With curl's default backoff this means 6 retry attempts.

