### PR TITLE
Add CLI to PATH in setup-cli

### DIFF
--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -20,6 +20,10 @@ runs:
           bash <(curl -fsSL --retry 10 --retry-all-errors --retry-max-time 60 https://metaplay.github.io/cli/install.sh) --version ${{ inputs.version }}
         fi
 
+    - name: Add CLI to PATH
+      shell: bash
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
     - name: Authenticate to Metaplay cloud
       shell: bash
       run: |


### PR DESCRIPTION
Add CLI installation path to GitHub PATH
This fixes error
```
metaplay: command not found
```