### PR TITLE
Add Windows support to setup-cli action

### DIFF
--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -40,7 +40,7 @@ runs:
         } else {
           $env:METAPLAY_VERSION = $version
         }
-        irm https://raw.githubusercontent.com/metaplay/cli/main/install.ps1 | iex
+        irm https://metaplay.github.io/cli/install.ps1 | iex
 
     - name: Add CLI to PATH (Windows)
       if: runner.os == 'Windows'

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -29,10 +29,16 @@ runs:
     - name: Install Metaplay CLI (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        $VerbosePreference = 'Continue'
-        if ("${{ inputs.version }}" -ne 'latest') {
-          $env:METAPLAY_VERSION = "${{ inputs.version }}"
+        $version = "${{ inputs.version }}"
+        if ($version -eq 'latest') {
+          $headers = @{ Authorization = "Bearer $env:GH_TOKEN"; 'User-Agent' = 'setup-cli-action' }
+          $release = Invoke-RestMethod -Uri "https://api.github.com/repos/metaplay/cli/releases/latest" -Headers $headers
+          $env:METAPLAY_VERSION = $release.tag_name
+        } else {
+          $env:METAPLAY_VERSION = $version
         }
         irm https://raw.githubusercontent.com/metaplay/cli/main/install.ps1 | iex
 

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -32,13 +32,8 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        $version = "${{ inputs.version }}"
-        if ($version -eq 'latest') {
-          $headers = @{ Authorization = "Bearer $env:GH_TOKEN"; 'User-Agent' = 'setup-cli-action' }
-          $release = Invoke-RestMethod -Uri "https://api.github.com/repos/metaplay/cli/releases/latest" -Headers $headers
-          $env:METAPLAY_VERSION = $release.tag_name
-        } else {
-          $env:METAPLAY_VERSION = $version
+        if ("${{ inputs.version }}" -ne "latest") {
+          $env:METAPLAY_VERSION = "${{ inputs.version }}"
         }
         irm https://metaplay.github.io/cli/install.ps1 | iex
 

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -30,6 +30,7 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
+        $VerbosePreference = 'Continue'
         if ("${{ inputs.version }}" -ne 'latest') {
           $env:METAPLAY_VERSION = "${{ inputs.version }}"
         }

--- a/setup-cli/action.yml
+++ b/setup-cli/action.yml
@@ -11,7 +11,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install Metaplay CLI
+    - name: Install Metaplay CLI (Linux/macOS)
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         if [ "${{ inputs.version }}" = "latest" ]; then
@@ -20,12 +21,27 @@ runs:
           bash <(curl -fsSL --retry 10 --retry-all-errors --retry-max-time 60 https://metaplay.github.io/cli/install.sh) --version ${{ inputs.version }}
         fi
 
-    - name: Add CLI to PATH
+    - name: Add CLI to PATH (Linux/macOS)
+      if: runner.os != 'Windows'
       shell: bash
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+    - name: Install Metaplay CLI (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if ("${{ inputs.version }}" -ne 'latest') {
+          $env:METAPLAY_VERSION = "${{ inputs.version }}"
+        }
+        irm https://raw.githubusercontent.com/metaplay/cli/main/install.ps1 | iex
+
+    - name: Add CLI to PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-Content $env:GITHUB_PATH "$env:LOCALAPPDATA\metaplay\bin"
+
     - name: Authenticate to Metaplay cloud
       shell: bash
-      run: |
-        export METAPLAY_CREDENTIALS=${{ inputs.credentials }}
-        metaplay auth machine-login
+      env:
+        METAPLAY_CREDENTIALS: ${{ inputs.credentials }}
+      run: metaplay auth machine-login


### PR DESCRIPTION
## Summary
- Split install/PATH steps by OS using `runner.os` condition
- Add PowerShell installer step for Windows (`install.ps1` via `irm | iex`)
- Add Windows PATH step (`%LOCALAPPDATA%\metaplay\bin`)
- Auth step uses `env:` instead of `export` for cross-platform compatibility

## Test plan
Add to a consumer repo to validate on Windows runner:
```yaml
jobs:
  test-windows:
    runs-on: windows-latest
    steps:
      - uses: metaplay-shared/github-workflows/setup-cli@feature/windows-support
        with:
          version: latest
          credentials: ${{ secrets.METAPLAY_CREDENTIALS }}
      - run: metaplay --version
```

## Open questions
- Confirm Windows install path is `%LOCALAPPDATA%\metaplay\bin` (assumed; validate on Windows runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)